### PR TITLE
Add perlin/simplex noise for basic terrain generation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pyglet
+noise


### PR DESCRIPTION
Referencing issue #5 

This adds simple perlin/simplex based terrain generation using the python library from https://github.com/caseman/noise. Installable via pip using `pip install noise`.

This patch however uses the python implementation, since the C implementation doesn't appear to have any good way to randomize the noise.

I also added a requirements.txt listing the current dependencies.
