### PR TITLE
Removed registry system

### DIFF
--- a/pycraft/main.py
+++ b/pycraft/main.py
@@ -2,7 +2,7 @@ import pyglet.app
 
 from pycraft.window import Window
 from pycraft.world import World
-from pycraft.player import Player
+from pycraft.objects.player import Player
 
 WINDOW_DIMENSIONS = (800, 600)
 WINDOW_CAPTION = 'PyCraft'

--- a/pycraft/objects/__init__.py
+++ b/pycraft/objects/__init__.py
@@ -1,3 +1,6 @@
-import pycraft.objects.block
-import pycraft.objects.item
-import pycraft.objects.enemy
+from pycraft.objects.block import Brick, Grass, Sand, Stone
+
+brick = Brick()
+grass = Grass()
+sand = Sand()
+stone = Stone()

--- a/pycraft/objects/block.py
+++ b/pycraft/objects/block.py
@@ -1,12 +1,10 @@
-from pycraft.objects.object import WorldObject, WorldObjectRegistry
+from pycraft.objects.object import WorldObject
 from pycraft.objects.textures import tex_coords
 
 GRASS = tex_coords((1, 0), (0, 1), (0, 0))
 SAND = tex_coords((1, 1), (1, 1), (1, 1))
 BRICK = tex_coords((2, 0), (2, 0), (2, 0))
 STONE = tex_coords((2, 1), (2, 1), (2, 1))
-
-objects = WorldObjectRegistry('blocks')
 
 
 class Block(WorldObject):
@@ -18,22 +16,18 @@ class Block(WorldObject):
         pass
 
 
-@objects.register('brick')
 class Brick(Block):
     texture = BRICK
 
 
-@objects.register('grass')
 class Grass(Block):
     texture = GRASS
 
 
-@objects.register('sand')
 class Sand(Block):
     texture = SAND
 
 
-@objects.register('stone')
 class Stone(Block):
     texture = STONE
 

--- a/pycraft/objects/enemy.py
+++ b/pycraft/objects/enemy.py
@@ -1,6 +1,4 @@
-from pycraft.objects.object import WorldObject, WorldObjectRegistry
-
-objects = WorldObjectRegistry('enemies')
+from pycraft.objects.object import WorldObject
 
 class Enemy(WorldObject):
     pass

--- a/pycraft/objects/item.py
+++ b/pycraft/objects/item.py
@@ -1,6 +1,4 @@
-from pycraft.objects.object import WorldObject, WorldObjectRegistry
-
-objects = WorldObjectRegistry('items')
+from pycraft.objects.object import WorldObject
 
 class Item(WorldObject):
     pass

--- a/pycraft/objects/object.py
+++ b/pycraft/objects/object.py
@@ -1,20 +1,3 @@
 
 class WorldObject:
     pass
-
-
-class WorldObjectRegistry:
-
-    objects = {}
-
-    def __init__(self, namespace=None):
-        self.namespace = namespace
-
-    def register(self, name):
-        def register_object(cls):
-            path = '%s.%s' % (self.namespace, name)
-            WorldObjectRegistry.objects[path] = cls()
-        return register_object
-
-    def get(self, path):
-        return WorldObjectRegistry.objects[path]

--- a/pycraft/objects/player.py
+++ b/pycraft/objects/player.py
@@ -1,0 +1,208 @@
+import math
+
+from pycraft.objects import brick, grass, sand
+from pycraft.objects.object import WorldObject
+from pycraft.util import normalize
+
+PLAYER_HEIGHT = 2
+GRAVITY = 20.0
+MAX_JUMP_HEIGHT = 2.0 # About the height of two blocks.
+# To derive the formula for calculating jump speed, first solve
+#    v_t = v_0 + a * t
+# for the time at which you achieve maximum height, where a is the acceleration
+# due to gravity and v_t = 0. This gives:
+#    t = - v_0 / a
+# Use t and the desired MAX_JUMP_HEIGHT to solve for v_0 (jump speed) in
+#    s = s_0 + v_0 * t + (a * t^2) / 2
+JUMP_SPEED = math.sqrt(2 * GRAVITY * MAX_JUMP_HEIGHT)
+TERMINAL_VELOCITY = 50
+WALKING_SPEED = 5
+FLYING_SPEED = 15
+FACES = [
+    ( 0, 1, 0),
+    ( 0,-1, 0),
+    (-1, 0, 0),
+    ( 1, 0, 0),
+    ( 0, 0, 1),
+    ( 0, 0,-1),
+]
+
+
+class Player(WorldObject):
+
+    def __init__(self):
+        # When flying gravity has no effect and speed is increased.
+        self.flying = False
+        # Strafing is moving lateral to the direction you are facing,
+        # e.g. moving to the left or right while continuing to face forward.
+        #
+        # First element is -1 when moving forward, 1 when moving back, and 0
+        # otherwise. The second element is -1 when moving left, 1 when moving
+        # right, and 0 otherwise.
+        self.strafe = [0, 0]
+        # Current (x, y, z) position in the world, specified with floats. Note
+        # that, perhaps unlike in math class, the y-axis is the vertical axis.
+        self.position = (0, 5, 0)
+        # First element is rotation of the player in the x-z plane (ground
+        # plane) measured from the z-axis down. The second is the rotation
+        # angle from the ground plane up. Rotation is in degrees.
+        #
+        # The vertical plane rotation ranges from -90 (looking straight down) to
+        # 90 (looking straight up). The horizontal rotation range is unbounded.
+        self.rotation = (0, 0)
+        # Velocity in the y (upward) direction.
+        self.dy = 0
+        # A list of blocks the player can place. Hit num keys to cycle.
+        self.inventory = [brick, grass, sand]
+        # The current block the user can place. Hit num keys to cycle.
+        self.block = self.inventory[0]
+
+    def strafe_forward(self):
+        self.strafe[0] -= 1
+
+    def strafe_backward(self):
+        self.strafe[0] += 1
+
+    def strafe_right(self):
+        self.strafe[1] += 1
+
+    def strafe_left(self):
+        self.strafe[1] -= 1
+
+    def jump(self):
+        """Increases vertical velocity, if grounded"""
+        if self.dy == 0: self.dy = JUMP_SPEED
+
+    def fly(self):
+        """Toggles flying mode"""
+        self.flying = not self.flying
+
+    def switch_inventory(self, index):
+        self.block = self.inventory[index % len(self.inventory)]
+
+    def get_sight_vector(self):
+        """Returns the current line of sight vector indicating the direction the
+        player is looking.
+        """
+        x, y = self.rotation
+        # y ranges from -90 to 90, or -pi/2 to pi/2, so m ranges from 0 to 1 and
+        # is 1 when looking ahead parallel to the ground and 0 when looking
+        # straight up or down.
+        m = math.cos(math.radians(y))
+        # dy ranges from -1 to 1 and is -1 when looking straight down and 1 when
+        # looking straight up.
+        dy = math.sin(math.radians(y))
+        dx = math.cos(math.radians(x - 90)) * m
+        dz = math.sin(math.radians(x - 90)) * m
+        return dx, dy, dz
+
+    def get_motion_vector(self):
+        """Returns the current motion vector indicating the velocity of the
+        player.
+
+        Returns
+        -------
+        vector : tuple of len 3
+            Tuple containing the velocity in x, y, and z respectively.
+        """
+        if any(self.strafe):
+            x, y = self.rotation
+            strafe = math.degrees(math.atan2(*self.strafe))
+            y_angle = math.radians(y)
+            x_angle = math.radians(x + strafe)
+            if self.flying:
+                m = math.cos(y_angle)
+                dy = math.sin(y_angle)
+                if self.strafe[1]:
+                    # Moving left or right.
+                    dy = 0.0
+                    m = 1
+                if self.strafe[0] > 0:
+                    # Moving backwards.
+                    dy *= -1
+                # When you are flying up or down, you have less left and right
+                # motion.
+                dx = math.cos(x_angle) * m
+                dz = math.sin(x_angle) * m
+            else:
+                dy = 0.0
+                dx = math.cos(x_angle)
+                dz = math.sin(x_angle)
+        else:
+            dy = 0.0
+            dx = 0.0
+            dz = 0.0
+        return dx, dy, dz
+
+    def update(self, dt, objects):
+        """Private implementation of the `update()` method. This is where most
+        of the motion logic lives, along with gravity and collision detection.
+
+        Parameters
+        ----------
+        dt : float
+            The change in time since the last call.
+        """
+        # walking
+        speed = FLYING_SPEED if self.flying else WALKING_SPEED
+        d = dt * speed  # distance covered this tick.
+        dx, dy, dz = self.get_motion_vector()
+        # New position in space, before accounting for gravity.
+        dx, dy, dz = dx * d, dy * d, dz * d
+        # gravity
+        if not self.flying:
+            # Update your vertical speed: if you are falling, speed up until you
+            # hit terminal velocity; if you are jumping, slow down until you
+            # start falling.
+            self.dy -= dt * GRAVITY
+            self.dy = max(self.dy, -TERMINAL_VELOCITY)
+            dy += self.dy * dt
+        # collisions
+        x, y, z = self.position
+        x, y, z = self.collide((x + dx, y + dy, z + dz), PLAYER_HEIGHT, objects)
+        self.position = (x, y, z)
+
+    def collide(self, position, height, objects):
+        """Checks to see if the player at the given `position` and `height`
+        is colliding with any blocks in the world.
+
+        Parametesrs
+        ----------
+        position : tuple of len 3
+            The (x, y, z) position to check for collisions at.
+        height : int or float
+            The height of the player.
+
+        Returns
+        -------
+        position : tuple of len 3
+            The new position of the player taking into account collisions.
+        """
+        # How much overlap with a dimension of a surrounding block you need to
+        # have to count as a collision. If 0, touching terrain at all counts as
+        # a collision. If .49, you sink into the ground, as if walking through
+        # tall grass. If >= .5, you'll fall through the ground.
+        pad = 0.25
+        p = list(position)
+        np = normalize(position)
+        for face in FACES:  # check all surrounding blocks
+            for i in range(3):  # check each dimension independently
+                if not face[i]:
+                    continue
+                # How much overlap you have with this dimension.
+                d = (p[i] - np[i]) * face[i]
+                if d < pad:
+                    continue
+                for dy in range(height):  # check each height
+                    op = list(np)
+                    op[1] -= dy
+                    op[i] += face[i]
+                    if tuple(op) not in objects:
+                        continue
+                    p[i] -= (d - pad) * face[i]
+                    if face == (0, -1, 0) or face == (0, 1, 0):
+                        # You are colliding with the ground or ceiling, so stop
+                        # falling / rising.
+                        self.dy = 0
+                    break
+        return tuple(p)

--- a/pycraft/window.py
+++ b/pycraft/window.py
@@ -6,7 +6,7 @@ import pyglet.window
 from pyglet.gl import *
 from pyglet.window import key, mouse
 
-from pycraft.objects.object import WorldObjectRegistry
+from pycraft.objects import brick, grass, sand, stone
 from pycraft.util import sectorize, cube_vertices
 
 TICKS_PER_SEC = 60
@@ -15,12 +15,6 @@ NUMERIC_KEYS = [
     key._1, key._2, key._3, key._4, key._5,
     key._6, key._7, key._8, key._9, key._0
 ]
-
-world_objects = WorldObjectRegistry()
-brick = world_objects.get('blocks.brick')
-grass = world_objects.get('blocks.grass')
-sand = world_objects.get('blocks.sand')
-stone = world_objects.get('blocks.stone')
 
 
 class Window(pyglet.window.Window):

--- a/pycraft/world.py
+++ b/pycraft/world.py
@@ -7,7 +7,7 @@ from pyglet.gl import *
 from pyglet.graphics import Batch, TextureGroup
 from pyglet.window import mouse
 
-from pycraft.objects.object import WorldObjectRegistry
+from pycraft.objects import brick, grass, sand, stone
 from pycraft.util import normalize, sectorize, cube_vertices, cube_shade
 from pycraft.shader import Shader
 
@@ -22,12 +22,6 @@ FACES = [
     ( 0, 0, 1),
     ( 0, 0,-1),
 ]
-
-world_objects = WorldObjectRegistry()
-brick = world_objects.get('blocks.brick')
-grass = world_objects.get('blocks.grass')
-sand = world_objects.get('blocks.sand')
-stone = world_objects.get('blocks.stone')
 
 
 class World:


### PR DESCRIPTION
I believe I've hacked my way out of implementing a registry system for the time being. While the codebase is still a bit unstable, I think it adds too much complexity for not a lot of benefit.

Additionally, I moved `player.py` into `pycraft/objects` and had it extend `WorldObject`, since it too is an object in the world and might benefit from some of that base class' functionality (and vice versa).

I think all `WorldObject`s should have an `update()` method, which would be a no-op by default. Players and enemies and things could add an implementation of `update()` in order to become more dynamic (i.e. move around and stuff). That'd be part of another pull request, though - for now, I just wanted to get rid of the registry system and move the `player.py` module.

Let me know if you have any questions!
