### PR TITLE
Issue29 - Travis and Coveralls integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = *__init__.py,*test*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+
+python:
+  - "3.5"
+
+install:
+  - pip install -r requirements.txt
+  - pip install -r requirements-dev.txt
+
+script:
+  - py.test
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,10 @@ python:
 install:
   - pip install -r requirements.txt
   - pip install -r requirements-dev.txt
+  - pip install coveralls
 
 script:
-  - py.test
+  - py.test --cov=. --cov-config .coveragerc .
 
+after_success:
+  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,5 @@ script:
   - py.test --cov=. --cov-config .coveragerc .
 
 after_success:
+  - coverage xml
   - coveralls

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://travis-ci.org/traverseda/pycraft.svg?branch=master
+    :target: https://travis-ci.org/traverseda/pycraft
+
 PyCraft
 =======
 

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,6 @@
 .. image:: https://travis-ci.org/traverseda/pycraft.svg?branch=master
     :target: https://travis-ci.org/traverseda/pycraft
+.. image:: https://coveralls.io/repos/github/traverseda/pycraft/badge.svg?branch=master :target: https://coveralls.io/github/traverseda/pycraft?branch=master
 
 PyCraft
 =======

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,5 @@
 coverage==4.0.3
 mock==2.0.0
 pytest==2.9.1
+pytest-cov==2.2.1
 pyyaml==3.11

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@
 coverage==4.0.3
 mock==2.0.0
 pytest==2.9.1
-pyyaml=3.11
+pyyaml==3.11

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 coverage==4.0.3
 mock==2.0.0
 pytest==2.9.1
+pyyaml=3.11

--- a/tests/test_licenses.py
+++ b/tests/test_licenses.py
@@ -56,6 +56,8 @@ def test_licenses(**options):
         'pytest-xdist'    # MIT
         'tox',            # MIT
         'virtualenv',     # MIT
+        # TravisCI automatically installs nose, which is licensed under the LGPL
+        'nose',           # LGPL
 
         # --------------------------------------------------------------
         # Known licenses that do not register with this test and can


### PR DESCRIPTION
Working Travis-CI tests and coverage reporting to Coveralls.

@traverseda If you haven't already, you'll need to go to coveralls.io and activate this repo on there. After that integration should just work.
