### PR TITLE
Fix players being able to place blocks inside of themselves

### DIFF
--- a/pycraft/objects/player.py
+++ b/pycraft/objects/player.py
@@ -55,8 +55,6 @@ class Player(WorldObject):
         self.rotation = (0, 0)
         # Velocity in the y (upward) direction.
         self.dy = 0
-        # A list of blocks the player begins with. Hit num keys to cycle.
-        self.inventory = ["brick", "grass", "sand", "weakstone"]
         # A dict of player blocks with their respective quantities
         self.items = {
             "brick": {
@@ -72,6 +70,9 @@ class Player(WorldObject):
                 "qty": 15
             }
         }
+
+        # this way you only have to modify the dict to add items to the starting inventory
+        self.inventory = list(self.items.keys())
         # The current block the user can place. Hit num keys to cycle.
         self.block = self.inventory[0]
 

--- a/pycraft/window.py
+++ b/pycraft/window.py
@@ -77,14 +77,12 @@ class Window(pyglet.window.Window):
             if (button == mouse.RIGHT) or \
                     ((button == mouse.LEFT) and (modifiers & key.MOD_CTRL)):
                 # ON OSX, control + left click = right click.
-                print("%s,%s" % (previous,normalize(self.player.position)))
                 player_x, player_y, player_z = normalize(self.player.position)
-                if previous and self.player.block and previous != (player_x, player_y, player_z) and previous != (player_x, player_y-1, player_z):
+                if previous and self.player.block and \
+                    previous != (player_x, player_y, player_z) and \
+                        previous != (player_x, player_y-1, player_z): # make sure the block isn't in the players head or feet
                     self.world.add_block(previous, get_block(self.player.block))
                     self.player.adjust_inventory(self.player.block)
-                    # print("ASS")
-
-                    # self.player.update(.1,self.world.objects)
 
             elif button == pyglet.window.mouse.LEFT and block:
                 texture = self.world.objects[block]

--- a/pycraft/window.py
+++ b/pycraft/window.py
@@ -77,7 +77,9 @@ class Window(pyglet.window.Window):
             if (button == mouse.RIGHT) or \
                     ((button == mouse.LEFT) and (modifiers & key.MOD_CTRL)):
                 # ON OSX, control + left click = right click.
-                if previous and self.player.block and previous.position:
+                print("%s,%s" % (previous,normalize(self.player.position)))
+                player_x, player_y, player_z = normalize(self.player.position)
+                if previous and self.player.block and previous != (player_x, player_y, player_z) and previous != (player_x, player_y-1, player_z):
                     self.world.add_block(previous, get_block(self.player.block))
                     self.player.adjust_inventory(self.player.block)
                     # print("ASS")

--- a/pycraft/window.py
+++ b/pycraft/window.py
@@ -6,7 +6,7 @@ import pyglet.window
 from pyglet.gl import *
 from pyglet.window import key, mouse
 
-from pycraft.util import sectorize, cube_vertices
+from pycraft.util import sectorize, cube_vertices, normalize
 from pycraft.objects.block import get_block
 
 #TICKS_PER_SEC = 60
@@ -77,9 +77,13 @@ class Window(pyglet.window.Window):
             if (button == mouse.RIGHT) or \
                     ((button == mouse.LEFT) and (modifiers & key.MOD_CTRL)):
                 # ON OSX, control + left click = right click.
-                if previous and self.player.block:
+                if previous and self.player.block and previous.position:
                     self.world.add_block(previous, get_block(self.player.block))
                     self.player.adjust_inventory(self.player.block)
+                    # print("ASS")
+
+                    # self.player.update(.1,self.world.objects)
+
             elif button == pyglet.window.mouse.LEFT and block:
                 texture = self.world.objects[block]
                 if texture.breakable:


### PR DESCRIPTION
The game will now not allow a player to place a block inside of themselves. Also I defined the starting inventory list based on the dict that contains the values- this means you'll only have to change it one place if you want to change it.
