### PR TITLE
Infinite terrain generator

### DIFF
--- a/pycraft/util.py
+++ b/pycraft/util.py
@@ -63,3 +63,21 @@ def sectorize(position):
     x, y, z = normalize(position)
     x, y, z = x // SECTOR_SIZE, y // SECTOR_SIZE, z // SECTOR_SIZE
     return x, 0, z
+
+def reverse_sectorize(sector):
+    """Returns an array of positions that would be found in a given sector.
+    Parameters
+    ----------
+    sector: tuple of len 3
+    Returns
+    -------
+    columns: tuple of len SECTOR_SIZE**2; containing tuples of len 2
+    """
+    columns  = []
+    sector_x,sector_z,sector_z = sector
+    x_start,z_start = sector_x*SECTOR_SIZE, sector_z*SECTOR_SIZE
+    x_end,z_end = x_start+SECTOR_SIZE, z_start+SECTOR_SIZE
+    for x in range(x_start,x_end):
+        for z in range(z_start,z_end):
+            columns += [(x,z)]
+    return tuple(columns)

--- a/pycraft/world.py
+++ b/pycraft/world.py
@@ -3,7 +3,13 @@ from collections import deque
 
 from noise.perlin import SimplexNoise
 from pyglet import image
-from pyglet.gl import *
+from pyglet.gl import glClearColor, glEnable, GL_CULL_FACE, glTexParameteri, \
+                         GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST, \
+                         GL_TEXTURE_MAG_FILTER, GL_FOG, glFogfv, GL_FOG_COLOR,\
+                         GLfloat, glHint, GL_FOG_HINT, GL_DONT_CARE, glFogi, \
+                         GL_FOG_MODE, GL_LINEAR, glFogf, GL_FOG_START, \
+                         GL_FOG_END, GL_QUADS
+
 from pyglet.graphics import Batch, TextureGroup
 from pyglet.window import mouse
 

--- a/pycraft/world.py
+++ b/pycraft/world.py
@@ -282,15 +282,15 @@ class World:
         """Generate blocks within sector using simplex_noise2
         """
         for column in reverse_sectorize(sector):
-                    x,z = column
-                    y_max = int((simplex_noise2(x / 30, z / 30) + 1) * 3)
-                    for y_lvl in range(0 - 2, y_max):
-                        self.add_block((x, y_lvl, z), sand, immediate=False)
-                    else:
-                        self.add_block((x, y_lvl, z), grass, immediate=False)
-                    # add the safety stone floor.
-                    # don't want anyone falling into the ether.
-                    self.add_block((x, 0 - 3, z), stone, immediate=False)
+            x,z = column
+            y_max = int((simplex_noise2(x / 30, z / 30) + 1) * 3)
+            for y_lvl in range(0 - 2, y_max):
+                self.add_block((x, y_lvl, z), sand, immediate=False)
+            else:
+                self.add_block((x, y_lvl, z), grass, immediate=False)
+            # add the safety stone floor.
+            # don't want anyone falling into the ether.
+            self.add_block((x, 0 - 3, z), stone, immediate=False)
             
 
     def hide_sector(self, sector):

--- a/pycraft/world.py
+++ b/pycraft/world.py
@@ -3,18 +3,18 @@ from collections import deque
 
 from noise.perlin import SimplexNoise
 from pyglet import image
-from pyglet.gl import glClearColor, glEnable, GL_CULL_FACE, glTexParameteri, \
-                         GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST, \
-                         GL_TEXTURE_MAG_FILTER, GL_FOG, glFogfv, GL_FOG_COLOR,\
-                         GLfloat, glHint, GL_FOG_HINT, GL_DONT_CARE, glFogi, \
-                         GL_FOG_MODE, GL_LINEAR, glFogf, GL_FOG_START, \
-                         GL_FOG_END, GL_QUADS
-
+from pyglet.gl import glClearColor, glEnable, GL_CULL_FACE, glTexParameteri,  \
+                      GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST,       \
+                      GL_TEXTURE_MAG_FILTER, GL_FOG, glFogfv, GL_FOG_COLOR,   \
+                      GLfloat, glHint, GL_FOG_HINT, GL_DONT_CARE, glFogi,     \
+                      GL_FOG_MODE, GL_LINEAR, glFogf, GL_FOG_START,           \
+                      GL_FOG_END, GL_QUADS                                    
 from pyglet.graphics import Batch, TextureGroup
 from pyglet.window import mouse
 
 from pycraft.objects import brick, grass, sand, stone
-from pycraft.util import normalize, sectorize, cube_vertices, cube_shade
+from pycraft.util import normalize, sectorize, reverse_sectorize, \
+                         cube_vertices, cube_shade
 from pycraft.shader import Shader
 
 simplex_noise2 = SimplexNoise(256).noise2
@@ -54,7 +54,7 @@ class World:
         # _show_block() and _hide_block() calls
         self.queue = deque()
         self.init_gl()
-        self._initialize()
+ #       self._initialize()
         self.init_shader()
 
     def init_gl(self):
@@ -268,9 +268,30 @@ class World:
         """Ensure all blocks in the given sector that should be shown are drawn
         to the canvas.
         """
-        for position in self.sectors.get(sector, []):
-            if position not in self.shown and self.exposed(position):
-                self.show_block(position, False)
+        positions = self.sectors.get(sector, [])
+        if positions:
+            for position in positions:
+                if position not in self.shown and self.exposed(position):
+                    self.show_block(position, False)
+        else:
+            self.generate_sector(sector)
+            self.show_sector(sector)
+            
+
+    def generate_sector(self, sector):
+        """Generate blocks within sector using simplex_noise2
+        """
+        for column in reverse_sectorize(sector):
+                    x,z = column
+                    y_max = int((simplex_noise2(x / 30, z / 30) + 1) * 3)
+                    for y_lvl in range(0 - 2, y_max):
+                        self.add_block((x, y_lvl, z), sand, immediate=False)
+                    else:
+                        self.add_block((x, y_lvl, z), grass, immediate=False)
+                    # add the safety stone floor.
+                    # don't want anyone falling into the ether.
+                    self.add_block((x, 0 - 3, z), stone, immediate=False)
+            
 
     def hide_sector(self, sector):
         """Ensure all blocks in the given sector that should be hidden are


### PR DESCRIPTION
#53

Things:

This will slow down the queue because there will be generation tasks on it as well as show/hide tasks.

Currently this is hooked into the show/hide sectors system. I'd like to change that.
Sectors need to have blocks generated before they can be shown, but I don't want the generation slowing down the showing.

Blocks are loaded into memory and never unloaded. This is concerning now that you can walk forever loading more and more of the things into memory. I'd like to see a change-manager that saves changes made to the environment as a layer to be overlaid onto the noise generated terrain. The terrain would need to be generated off of a common seed for this.
