### PR TITLE
Repairs of test_util and upgrade of test_Licences

### DIFF
--- a/tests/test_licenses.py
+++ b/tests/test_licenses.py
@@ -20,6 +20,8 @@ def test_licenses(**options):
     '''
     meta_files_to_check = ['PKG-INFO', 'METADATA']
 
+    failed = False
+
     known_ignores = [
         # --------------------------------------------------------------
         # Pip packages added
@@ -126,6 +128,9 @@ def test_licenses(**options):
             license=license
         )
         print(msg, file=file)
-        assert found_license is True
-        if project_name not in known_ignores:
-            assert found_valid is True
+        if found_license is False:
+            failed = True
+        if project_name not in known_ignores and found_valid is False:
+            failed = True
+    assert not failed, "Some licences were not approved or not found"
+

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -23,7 +23,7 @@ def test_normalize():
     Test the normalize function.
     """
     my_pos = [3.29, 5.9, 7.001]
-    expected = [3, 5, 7]
+    expected = [3, 6, 7]
     norm_pos = util.normalize(my_pos)
     for i, e in zip(norm_pos, expected):
         assert isinstance(i, int), "Returned position not an integer"


### PR DESCRIPTION
Changes expectation that round 5.9 is 5 but in reality is 6
Upgraded test_licences so that it checks every module before it failes, now one
can see everyone that failed not only one
