### PR TITLE
Fixed WeakStone

### DIFF
--- a/pycraft/objects/__init__.py
+++ b/pycraft/objects/__init__.py
@@ -1,7 +1,7 @@
-from .block import Brick, Grass, Sand, Stone, WeakStone
+from .block import Brick, Grass, Sand, Stone, Weakstone
 
 brick = Brick()
 grass = Grass()
 sand = Sand()
-weak_stone = WeakStone()
+weak_stone = Weakstone()
 stone = Stone()

--- a/pycraft/objects/block.py
+++ b/pycraft/objects/block.py
@@ -54,8 +54,8 @@ class Sand(Block):
     durability = 2
 
 
-class WeakStone(Block):
-    identifier = 'WeakStone'
+class Weakstone(Block):
+    identifier = 'Weakstone'
     texture = STONE
     breakable = True
     durability = 15

--- a/pycraft/objects/player.py
+++ b/pycraft/objects/player.py
@@ -1,6 +1,6 @@
 import math
 
-from .block import Brick, Grass, Sand, WeakStone
+from .block import Brick, Grass, Sand, Weakstone
 from .object import WorldObject
 from ..util import normalize
 


### PR DESCRIPTION
This fixes #75  
Renaming Weak**S**tone class and all its references to Weak**s**tone.
Line 30 in block.py: classname = globals()[identifier.capitalize()]
Since "weakstone".capitalize() is "Weak**s**tone", but the name of the class is Weak**S**tone, it raised KeyError exception.
