### PR TITLE
Addressing issue #78

### DIFF
--- a/pycraft/window.py
+++ b/pycraft/window.py
@@ -50,8 +50,6 @@ class Window(pyglet.window.Window):
             mouse button was clicked.
         """
 
-        self.gamestatemanager.peek().on_mouse_press(x, y, button, modifiers)
-
         if self.exclusive:
             self.gamestatemanager.peek().on_mouse_press(x, y, button, modifiers)
         else:


### PR DESCRIPTION
removing the first line of self.gamestatemanager.peek().on_mouse_press(x, y, button, modifiers) should fix the double block placement problem
