### PR TITLE
docs: fix simple typo, obtian -> obtain

### DIFF
--- a/pycraft/shader.py
+++ b/pycraft/shader.py
@@ -139,7 +139,7 @@ class Shader:
     # works with matrices stored as lists,
     # as well as euclid matrices
     def uniform_matrixf(self, name, mat):
-        # obtian the uniform location
+        # obtain the uniform location
         loc = glGetUniformLocation(self.handle, name)
         # uplaod the 4x4 floating point matrix
         glUniformMatrix4fv(loc, 1, False, (c_float * 16)(*mat))


### PR DESCRIPTION
There is a small typo in pycraft/shader.py.

Should read `obtain` rather than `obtian`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md